### PR TITLE
 Fix internal link in "Devops-lessons-Preparation"

### DIFF
--- a/source/advanced-introduction-to-devops/devops-lessons-preparation.md
+++ b/source/advanced-introduction-to-devops/devops-lessons-preparation.md
@@ -410,7 +410,7 @@
 
 - Git commands
 
-  - [Git commands Webpage](https://www.youtube.com/watch?v=PSJ63LULKHA)
+  - [Git commands Webpage](https://www.hostinger.com/tutorials/basic-git-commands)
 
   - [Git commands Video](https://www.youtube.com/watch?v=PSJ63LULKHA)
 

--- a/source/advanced-introduction-to-devops/devops-lessons-preparation.md
+++ b/source/advanced-introduction-to-devops/devops-lessons-preparation.md
@@ -388,7 +388,7 @@
 
 - Docker
 
-  - [Docker Webpage](https://www.ibm.com/in-en/cloud/learn/docker)
+  - [Docker Webpage](https://www.ibm.com/topics/docker)
 
   - [Docker Video](https://www.youtube.com/watch?v=_dfLOzuIg2o)
 


### PR DESCRIPTION
fix the link of  "Docker Webpage"