### PR TITLE
Fix: Add 2025 news link to source/news/README.md

### DIFF
--- a/source/news/README.md
+++ b/source/news/README.md
@@ -2,3 +2,4 @@
 
 - [📰 2023 ](./source/news-2023.md "News 2023")
 - [📰 2024 ](./source/news-2024.md "News 2024")
+- [📰 2025 ](./source/news-2025.md "News 2025")


### PR DESCRIPTION
## Problem
- The `source/news/README.md` only listed 2023 and 2024 news links
- The `source/news/source/news-2025.md` file exists with content (211 lines)
- Main `README.md` already references 2025 news, creating inconsistency

## Solution
- Added 2025 news link following the established pattern
- Maintains consistency across documentation  
- Improves discoverability of 2025 news content

## Type of Change
- [x] Documentation consistency fix
- [x] Follows contribution guidelines for direct fixes

## Testing
- [x] Verified file path exists: `source/news/source/news-2025.md`
- [x] Follows exact format of existing 2023/2024 entries
- [x] Maintains proper markdown formatting