### PR TITLE
Fix: Update Dynamic analysis for code Video link to public alternative

### DIFF
--- a/source/advanced-introduction-to-devops/source/devops-lessons-preparation.md
+++ b/source/advanced-introduction-to-devops/source/devops-lessons-preparation.md
@@ -170,7 +170,7 @@
 
   - [Dynamic analysis for code Webpage](https://www.harness.io/blog/static-vs-dynamic-code-analysis)
 
-  - [Dynamic analysis for code Video](https://www.youtube.com/watch?v=seuW81p4gv4)
+  - [Dynamic analysis for code Video](https://youtu.be/HDg1bCuq0AE)
 
 - Unit testing
 


### PR DESCRIPTION
Replaced the private/unavailable video link with a public YouTube link for Dynamic analysis for code in Module 2 preparation points. As per the reviewer's request, this PR now only includes the video link fix.